### PR TITLE
use io_blob response directly from sisl generic rpc data

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.50.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "2.0.5"
+    version = "2.1.1"
 
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"

--- a/conanfile.py
+++ b/conanfile.py
@@ -58,7 +58,7 @@ class NuRaftMesgConan(ConanFile):
             self.build_requires("jungle/cci.20221201")
 
     def requirements(self):
-        self.requires("sisl/[~=10, include_prerelease=True]@oss/master")
+        self.requires("sisl/[~=11, include_prerelease=True]@oss/master")
         self.requires("nuraft/2.3.0")
 
         self.requires("boost/1.82.0")

--- a/include/nuraft_mesg/nuraft_mesg.hpp
+++ b/include/nuraft_mesg/nuraft_mesg.hpp
@@ -45,8 +45,7 @@ namespace nuraft_mesg {
 class mesg_state_mgr;
 
 // called by the server after it receives the request
-using data_service_request_handler_t =
-    std::function< void(sisl::io_blob const& incoming_buf, boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) >;
+using data_service_request_handler_t = std::function< void(boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) >;
 
 class MessagingApplication {
 public:

--- a/src/lib/common_lib.hpp
+++ b/src/lib/common_lib.hpp
@@ -17,7 +17,7 @@ namespace nuraft_mesg {
 [[maybe_unused]] static void serialize_to_byte_buffer(grpc::ByteBuffer& cli_byte_buf, io_blob_list_t const& cli_buf) {
     folly::small_vector< grpc::Slice, 4 > slices;
     for (auto const& blob : cli_buf) {
-        slices.emplace_back(blob.bytes, blob.size, grpc::Slice::STATIC_SLICE);
+        slices.emplace_back(blob.cbytes(), blob.size(), grpc::Slice::STATIC_SLICE);
     }
     cli_byte_buf.Clear();
     grpc::ByteBuffer tmp(slices.data(), cli_buf.size());
@@ -29,8 +29,8 @@ namespace nuraft_mesg {
     grpc::Slice slice;
     auto status = cli_byte_buf.TrySingleSlice(&slice);
     if (!status.ok()) { return status; }
-    cli_buf.bytes = const_cast< uint8_t* >(slice.begin());
-    cli_buf.size = slice.size();
+    cli_buf.set_bytes(slice.begin());
+    cli_buf.set_size(slice.size());
     return status;
 }
 

--- a/src/lib/data_service_grpc.cpp
+++ b/src/lib/data_service_grpc.cpp
@@ -33,13 +33,7 @@ bool data_service_grpc::bind(std::string const& request_name, group_id_t const& 
     // This is an async call, hence the "return false". The user should invoke rpc_data->send_response to finish the
     // call
     auto generic_handler_cb = [request_cb](boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
-        sisl::io_blob svr_buf;
-        if (auto status = deserialize_from_byte_buffer(rpc_data->request(), svr_buf); !status.ok()) {
-            LOGE(, "ByteBuffer DumpToSingleSlice failed, {}", status.error_message());
-            rpc_data->set_status(status);
-            return true; // respond immediately
-        }
-        request_cb(svr_buf, rpc_data);
+        request_cb(rpc_data);
         return false;
     };
     auto lk = std::unique_lock< data_lock_type >(_req_lock);

--- a/src/tests/test_state_manager.cpp
+++ b/src/tests/test_state_manager.cpp
@@ -208,8 +208,8 @@ bool test_state_mgr::register_data_service_apis(nuraft_mesg::Manager* messaging)
 }
 
 void test_state_mgr::verify_data(sisl::io_blob const& buf) {
-    for (size_t read_sz{0}; read_sz < buf.size; read_sz += sizeof(uint32_t)) {
-        uint32_t const data{*reinterpret_cast< uint32_t* >(buf.bytes + read_sz)};
+    for (size_t read_sz{0}; read_sz < buf.size(); read_sz += sizeof(uint32_t)) {
+        uint32_t const data{*reinterpret_cast< uint32_t* >(const_cast< uint8_t* >(buf.cbytes()) + read_sz)};
         EXPECT_EQ(data, data_vec[read_sz / sizeof(uint32_t)]);
     }
 }
@@ -218,7 +218,7 @@ void test_state_mgr::fill_data_vec(nuraft_mesg::io_blob_list_t& cli_buf) {
     static int const data_size{8};
     for (int i = 0; i < data_size; i++) {
         cli_buf.emplace_back(sizeof(uint32_t));
-        uint32_t* const write_buf{reinterpret_cast< uint32_t* >(cli_buf[i].bytes)};
+        uint32_t* const write_buf{reinterpret_cast< uint32_t* >(cli_buf[i].bytes())};
         data_vec.emplace_back(get_random_num());
         *write_buf = data_vec.back();
     }

--- a/src/tests/test_state_manager.cpp
+++ b/src/tests/test_state_manager.cpp
@@ -193,16 +193,17 @@ test_state_mgr::data_service_request_unidirectional(nuraft_mesg::destination_t c
 bool test_state_mgr::register_data_service_apis(nuraft_mesg::Manager* messaging) {
     return messaging->bind_data_service_request(
                SEND_DATA, _group_id,
-               [this](sisl::io_blob const& incoming_buf, boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
+               [this](boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
                    rpc_data->set_comp_cb([this](boost::intrusive_ptr< sisl::GenericRpcData >&) { server_counter++; });
-                   verify_data(incoming_buf);
-                   m_repl_svc_ctx->send_data_service_response(nuraft_mesg::io_blob_list_t{incoming_buf}, rpc_data);
+                   verify_data(rpc_data->request_blob());
+                   m_repl_svc_ctx->send_data_service_response(nuraft_mesg::io_blob_list_t{rpc_data->request_blob()},
+                                                              rpc_data);
                }) &&
         messaging->bind_data_service_request(
-            REQUEST_DATA, _group_id,
-            [this](sisl::io_blob const& incoming_buf, boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
+            REQUEST_DATA, _group_id, [this](boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
                 rpc_data->set_comp_cb([this](boost::intrusive_ptr< sisl::GenericRpcData >&) { server_counter++; });
-                m_repl_svc_ctx->send_data_service_response(nuraft_mesg::io_blob_list_t{incoming_buf}, rpc_data);
+                m_repl_svc_ctx->send_data_service_response(nuraft_mesg::io_blob_list_t{rpc_data->request_blob()},
+                                                           rpc_data);
             });
 }
 


### PR DESCRIPTION
This fixes the issue where we fail when grpc server response buffer is made up of single slice. We let sisl manage the buf and give us the io_blob.
TODO: change the deserialize function we use for the grpc generic client. 

This is a breaking change and requires major ver upgrade. As the only consumer is Homestore ATM, this PR only updates minor. 