### PR TITLE
update lz4 and opessl version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ cmake-build*
 build/
 compile_commands*
 .clangd/
+.vscode/
 .cache/

--- a/conanfile.py
+++ b/conanfile.py
@@ -63,8 +63,8 @@ class NuRaftMesgConan(ConanFile):
 
         self.requires("boost/1.82.0")
         self.requires("flatbuffers/23.5.26")
-        self.requires("openssl/3.1.1")
-        self.requires("lz4/1.9.4")
+        self.requires("openssl/3.1.3")
+        self.requires("lz4/1.9.3")
 
     def validate(self):
         if self.info.settings.compiler.cppstd:


### PR DESCRIPTION
lz4 has conflict with folly
openssl has conflict with sisl11

update lz4 and opessl version to be compitable with sisl11 and folly

after this PR and https://github.com/eBay/sisl/pull/200 are both merged , homestore repl branch merging master (https://github.com/eBay/HomeStore/pull/266) can be built with iomgr 11, which depends sisl11