### PR TITLE
Exposing Leader to upper layer.

### DIFF
--- a/src/include/messaging_if.hpp
+++ b/src/include/messaging_if.hpp
@@ -64,6 +64,7 @@ public:
     // we do not own this pointer. Use this only if the lyfe cycle of the pointer is well known
     grpc_server* m_server;
     bool is_raft_leader() const;
+    const std::string& raft_leader_id() const;
 
     // data service api client call
     virtual std::error_condition data_service_request(std::string const& request_name, io_blob_list_t const& cli_buf,

--- a/src/lib/messaging.cpp
+++ b/src/lib/messaging.cpp
@@ -436,6 +436,15 @@ repl_service_ctx::repl_service_ctx(grpc_server* server) : m_server(server) {}
 
 bool repl_service_ctx::is_raft_leader() const { return m_server->raft_server()->is_leader(); }
 
+const std::string& repl_service_ctx::raft_leader_id() const {
+    // when adding member to raft,  the id recorded in raft is a hash
+    // of passed-in id (new_id in add_member()), the new_id was stored
+    // in endpoint field.
+    auto leader_svc_id = m_server->raft_server()->get_leader_id();
+    auto cfg = m_server->raft_server->get_srv_config(leader_svc_id);
+    return cfg->get_endpoint();
+}
+
 repl_service_ctx_grpc::repl_service_ctx_grpc(grpc_server* server, std::shared_ptr< mesg_factory > const& cli_factory) :
         repl_service_ctx(server), m_mesg_factory(cli_factory) {}
 


### PR DESCRIPTION
SM needs to return leader in both response of some API call as well as PGStat report.

This helps client(of SM)  to know up-to-date leader and send requests to leader.