### PR TITLE
Exposing Leader to upper layer

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.50.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "2.1.2"
+    version = "2.2.2"
 
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"

--- a/include/nuraft_mesg/mesg_state_mgr.hpp
+++ b/include/nuraft_mesg/mesg_state_mgr.hpp
@@ -36,7 +36,7 @@ public:
     // we do not own this pointer. Use this only if the life cycle of the pointer is well known
     nuraft::raft_server* _server;
     bool is_raft_leader() const;
-    std::string_view raft_leader_id() const;
+    const std::string& raft_leader_id() const;
 
     // return a list of replica configs for the peers of the raft group
     void get_cluster_config(std::list< replica_config >& cluster_config) const;

--- a/include/nuraft_mesg/mesg_state_mgr.hpp
+++ b/include/nuraft_mesg/mesg_state_mgr.hpp
@@ -36,6 +36,7 @@ public:
     // we do not own this pointer. Use this only if the life cycle of the pointer is well known
     nuraft::raft_server* _server;
     bool is_raft_leader() const;
+    std::string_view raft_leader_id() const;
 
     // return a list of replica configs for the peers of the raft group
     void get_cluster_config(std::list< replica_config >& cluster_config) const;

--- a/src/lib/repl_service_ctx.cpp
+++ b/src/lib/repl_service_ctx.cpp
@@ -64,6 +64,19 @@ repl_service_ctx::repl_service_ctx(nuraft::raft_server* server) : _server(server
 
 bool repl_service_ctx::is_raft_leader() const { return _server->is_leader(); }
 
+std::string_view repl_service_ctx::raft_leader_id() const {
+    // when adding member to raft,  the id recorded in raft is a hash
+    // of passed-in id (new_id in add_member()), the new_id was stored
+    // in endpoint field.
+    if (!_server)
+        return std::string_view();
+    if (auto leader = _server->get_srv_config(_server->get_leader()); nullptr != leader) {
+        static_assert(std::is_reference<decltype(leader->get_endpoint())>::value);
+        return leader->get_endpoint();
+    }
+    return std::string_view();
+}
+
 void repl_service_ctx::get_cluster_config(std::list< replica_config >& cluster_config) const {
     auto const& srv_configs = _server->get_config()->get_servers();
     for (auto const& srv_config : srv_configs) {

--- a/src/lib/repl_service_ctx.cpp
+++ b/src/lib/repl_service_ctx.cpp
@@ -64,17 +64,17 @@ repl_service_ctx::repl_service_ctx(nuraft::raft_server* server) : _server(server
 
 bool repl_service_ctx::is_raft_leader() const { return _server->is_leader(); }
 
-std::string_view repl_service_ctx::raft_leader_id() const {
+const std::string& repl_service_ctx::raft_leader_id() const {
     // when adding member to raft,  the id recorded in raft is a hash
     // of passed-in id (new_id in add_member()), the new_id was stored
     // in endpoint field.
-    if (!_server)
-        return std::string_view();
+    static std::string const empty;
+    if (!_server) return empty;
     if (auto leader = _server->get_srv_config(_server->get_leader()); nullptr != leader) {
-        static_assert(std::is_reference<decltype(leader->get_endpoint())>::value);
+        static_assert(std::is_reference< decltype(leader->get_endpoint()) >::value);
         return leader->get_endpoint();
     }
-    return std::string_view();
+    return empty;
 }
 
 void repl_service_ctx::get_cluster_config(std::list< replica_config >& cluster_config) const {

--- a/src/tests/data_service_tests.cpp
+++ b/src/tests/data_service_tests.cpp
@@ -125,6 +125,17 @@ TEST_F(DataServiceFixture, BasicTest2) {
     auto repl_ctx = sm1->get_repl_context();
 
     EXPECT_TRUE(repl_ctx && repl_ctx->is_raft_leader());
+    EXPECT_TRUE(repl_ctx && repl_ctx->raft_leader_id() == to_string(app_1_->id_));
+
+    auto repl_ctx_2 = app_2_->state_mgr_map_[group_id_]->get_repl_context();
+    EXPECT_TRUE(repl_ctx_2 && !repl_ctx_2->is_raft_leader());
+    EXPECT_TRUE(repl_ctx_2 && repl_ctx_2->raft_leader_id() == to_string(app_1_->id_));
+
+    auto repl_ctx_3 = app_3_->state_mgr_map_[group_id_]->get_repl_context();
+    EXPECT_TRUE(repl_ctx_3 && !repl_ctx_3->is_raft_leader());
+    EXPECT_TRUE(repl_ctx_3 && repl_ctx_3->raft_leader_id() == to_string(app_1_->id_));
+
+
     std::list< nuraft_mesg::replica_config > cluster_config;
     repl_ctx->get_cluster_config(cluster_config);
     EXPECT_EQ(cluster_config.size(), 3u);

--- a/src/tests/data_service_tests.cpp
+++ b/src/tests/data_service_tests.cpp
@@ -135,7 +135,6 @@ TEST_F(DataServiceFixture, BasicTest2) {
     EXPECT_TRUE(repl_ctx_3 && !repl_ctx_3->is_raft_leader());
     EXPECT_TRUE(repl_ctx_3 && repl_ctx_3->raft_leader_id() == to_string(app_1_->id_));
 
-
     std::list< nuraft_mesg::replica_config > cluster_config;
     repl_ctx->get_cluster_config(cluster_config);
     EXPECT_EQ(cluster_config.size(), 3u);


### PR DESCRIPTION
SM needs to return leader in both response of some API call as well as PGStat report.

This helps client(of SM)  to know up-to-date leader and send requests to leader.