### PR TITLE
Add get_raft_status() API

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.50.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "2.3.2"
+    version = "2.3.1"
 
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.50.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "2.2.2"
+    version = "2.3.2"
 
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"

--- a/include/nuraft_mesg/mesg_state_mgr.hpp
+++ b/include/nuraft_mesg/mesg_state_mgr.hpp
@@ -28,6 +28,15 @@ struct replica_config {
     std::string aux;
 };
 
+struct peer_info {
+    // Peer ID.
+    std::string id_;
+    // The last log index that the peer has, from this server's point of view.
+    ulong last_log_idx_;
+    // The elapsed time since the last successful response from this peer, set to 0 on leader
+    ulong last_succ_resp_us_;
+};
+
 class repl_service_ctx {
 public:
     repl_service_ctx(nuraft::raft_server* server);
@@ -37,6 +46,7 @@ public:
     nuraft::raft_server* _server;
     bool is_raft_leader() const;
     const std::string& raft_leader_id() const;
+    std::vector< peer_info >get_raft_status() const;
 
     // return a list of replica configs for the peers of the raft group
     void get_cluster_config(std::list< replica_config >& cluster_config) const;

--- a/include/nuraft_mesg/mesg_state_mgr.hpp
+++ b/include/nuraft_mesg/mesg_state_mgr.hpp
@@ -32,9 +32,9 @@ struct peer_info {
     // Peer ID.
     std::string id_;
     // The last log index that the peer has, from this server's point of view.
-    ulong last_log_idx_;
+    uint64_t last_log_idx_;
     // The elapsed time since the last successful response from this peer, set to 0 on leader
-    ulong last_succ_resp_us_;
+    uint64_t last_succ_resp_us_;
 };
 
 class repl_service_ctx {


### PR DESCRIPTION
This API will returns Peer_info struct for all members including leader.

The main purpose of this API is for HO->SM->CM report so SM/CM can decide which peers are considered up-to-date.