### PR TITLE
fix get peer info

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "3.6.2"
+    version = "3.6.3"
 
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"

--- a/src/lib/repl_service_ctx.cpp
+++ b/src/lib/repl_service_ctx.cpp
@@ -111,9 +111,12 @@ std::vector< peer_info > repl_service_ctx::get_raft_status() const {
         }
     }
 
+    auto my_id = _server->get_id();
+    auto my_peer_id = _server->get_srv_config(my_id)->get_endpoint();
+
     // add the peer info of itself(leader or follower) , which is useful for upper layer
     // from the view a node itself, last_succ_resp_us_ make no sense, so set it to 0
-    peers.emplace_back(peer_info{std::string(_server->get_id()), _server->get_last_log_idx(), 0});
+    peers.emplace_back(my_peer_id, _server->get_last_log_idx(), 0);
 
     return peers;
 }


### PR DESCRIPTION
1 fix a bug that a peer does not exist in the configuration of leader 

for remove_member case , leader will first remove the member from peer_list, and then apply the new cluster configuraiton which excludes the removed member. if a leader get peer_list before the to-be-removed node is removed from the  peer_list, and then try to  get_srv_config after the node is removed for the cluster config (new config is applied), then it can not find this peer in the configuration.

2 support follower to get its own peer info , which is useful for upper layer to get the last append log index of a follower.
