### PR TITLE
fix get peer info of removed member

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "3.6.3"
+    version = "3.6.4"
 
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"


### PR DESCRIPTION
in nuobject test, a removed member will try to get the info of itself to identify whether it is in a pg. but ATM , it is not in the configuration of this raft group. this PR aims to handle this case.