### PR TITLE
Simplify the raft_event callback for mesg_state_mgr.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "3.7.0"
+    version = "3.7.1"
 
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"

--- a/include/nuraft_mesg/mesg_state_mgr.hpp
+++ b/include/nuraft_mesg/mesg_state_mgr.hpp
@@ -79,9 +79,14 @@ public:
     virtual void permanent_destroy() = 0;
     virtual void leave() = 0;
 
-    virtual std::pair< bool, nuraft::cb_func::ReturnCode > handle_raft_event(nuraft::cb_func::Type,
-                                                                             nuraft::cb_func::Param*) {
-        return std::pair(false, nuraft::cb_func::ReturnCode::Ok);
+    /// TODO: Deprecated DO NOT USE
+    virtual std::pair< bool, nuraft::cb_func::ReturnCode > handle_raft_event(nuraft::cb_func::Type t,
+                                                                             nuraft::cb_func::Param* p) {
+        return std::pair(false, raft_event(t, p));
+    }
+
+    virtual nuraft::cb_func::ReturnCode raft_event(nuraft::cb_func::Type, nuraft::cb_func::Param*) {
+        return nuraft::cb_func::ReturnCode::Ok;
     }
 
     nuraft::cb_func::ReturnCode internal_raft_event_handler(group_id_t const& group_id, nuraft::cb_func::Type type,

--- a/src/lib/manager_impl.hpp
+++ b/src/lib/manager_impl.hpp
@@ -92,8 +92,8 @@ public:
     nuraft::cmd_result_code group_init(int32_t const srv_id, group_id_t const& group_id, group_type_t const& group_type,
                                        nuraft::context*& ctx, std::shared_ptr< group_metrics > metrics);
     void start(bool and_data_svc);
-    nuraft::cb_func::ReturnCode generic_raft_event_handler(group_id_t const& group_id, nuraft::cb_func::Type type,
-                                                           nuraft::cb_func::Param* param);
+    void generic_raft_event_handler(group_id_t const& group_id, nuraft::cb_func::Type type,
+                                    nuraft::cb_func::Param* param);
 
     //
 };


### PR DESCRIPTION
Existing implementation was clumsy and incorrect. Simplify.