### PR TITLE
fix: use peer's last log idx rather than leader's last log idx

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.60.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "3.8.1"
+    version = "3.8.2"
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"
     topics = ("ebay", "nublox", "raft")

--- a/src/lib/repl_service_ctx.cpp
+++ b/src/lib/repl_service_ctx.cpp
@@ -107,7 +107,7 @@ std::vector< peer_info > repl_service_ctx::get_raft_status() const {
                     continue;
                 }
                 // default priority=1
-                peer.last_log_idx_ = _server->get_last_log_idx();
+                peer.last_log_idx_ = pinfo.last_log_idx_;
                 peer.last_succ_resp_us_ = pinfo.last_succ_resp_us_;
                 peer.priority_ = srv_config->get_priority();
                 peer.is_learner_ = srv_config->is_learner();


### PR DESCRIPTION
This change prevents the upper layer from incorrectly assuming that all members are in sync by using the leader's last log index.