### PR TITLE
Skip peer that doesnt have config.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.60.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "3.8.2"
+    version = "3.8.3"
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"
     topics = ("ebay", "nublox", "raft")

--- a/src/lib/repl_service_ctx.cpp
+++ b/src/lib/repl_service_ctx.cpp
@@ -112,8 +112,10 @@ std::vector< peer_info > repl_service_ctx::get_raft_status() const {
                 peer.priority_ = srv_config->get_priority();
                 peer.is_learner_ = srv_config->is_learner();
                 peer.is_new_joiner_ = srv_config->is_new_joiner();
+                peers.emplace_back(peer);
+            } else {
+                LOGW("do not find peer id  {} in the conifg of leader", pinfo.id_);
             }
-            peers.emplace_back(peer);
         }
     }
 


### PR DESCRIPTION
Previously if a peer doesnt show in leader's cluster config, an empty peer will be returned then later upstream panic when trying to convert peer_id into int.