### PR TITLE
Add configuration for console log output

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.60.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "3.8.4"
+    version = "3.8.5"
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"
     topics = ("ebay", "nublox", "raft")

--- a/include/nuraft_mesg/nuraft_mesg.hpp
+++ b/include/nuraft_mesg/nuraft_mesg.hpp
@@ -66,6 +66,7 @@ public:
         std::shared_ptr< sisl::GrpcTokenClient > token_client_{nullptr};
         int max_receive_message_size_{0};
         int max_send_message_size_{0};
+        bool enable_console_log_{false};
     };
     using group_params = nuraft::raft_params;
     virtual ~Manager() = default;

--- a/src/lib/manager_impl.cpp
+++ b/src/lib/manager_impl.cpp
@@ -69,7 +69,9 @@ ManagerImpl::ManagerImpl(Manager::Params const& start_params, std::weak_ptr< Mes
     // NOTE: The Unit tests require this instance to be recreated with the same parameters.
     // This exception is only expected in this case where we "restart" the server by just recreating the instance.
     try {
-        _custom_logger = sisl::logging::CreateCustomLogger(logger_name, "", false, false /* tee_to_stdout_stderr */);
+        _custom_logger = sisl::logging::CreateCustomLogger(logger_name, "",
+                                                           start_params_.enable_console_log_,
+                                                           start_params_.enable_console_log_ /* tee_to_stdout_stderr */);
     } catch (spdlog::spdlog_ex const& e) { _custom_logger = spdlog::details::registry::instance().get(logger_name); }
 
     sisl::logging::SetLogPattern("[%D %T.%f] [%^%L%$] [%t] %v", _custom_logger);


### PR DESCRIPTION
This change adds a new param `enable_console_log_`, allowing upper layers to decide whether to tee logs to the console. This will help Sherlock collect logs more easily.