### PR TITLE
shutdown rpc server before reset a new one 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.60.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "3.8.7"
+    version = "3.8.8"
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"
     topics = ("ebay", "nublox", "raft")

--- a/src/lib/manager_impl.cpp
+++ b/src/lib/manager_impl.cpp
@@ -113,6 +113,7 @@ void ManagerImpl::restart_server() {
         return;
     }
 
+    if (_grpc_server) { _grpc_server->shutdown(); }
     _grpc_server.reset();
     _grpc_server = std::unique_ptr< sisl::GrpcServer >(tmp_server);
     _mesg_service->associate(_grpc_server.get());


### PR DESCRIPTION
Fix [crash issue](https://github.com/eBay/HomeStore/issues/795) when cert change: 
Explicitly shutdown the RPC server before resetting to ensure all asynchronous requests are completed, preventing concurrency issues with active RPC requests.
