### PR TITLE
SDSTOR-24260: create new grpc_proto_client wrapper on reinit

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.60.0"
 
 class NuRaftMesgConan(ConanFile):
     name = "nuraft_mesg"
-    version = "4.0.5"
+    version = "4.0.6"
     homepage = "https://github.com/eBay/nuraft_mesg"
     description = "A gRPC service for NuRAFT"
     topics = ("ebay", "nublox", "raft")

--- a/include/nuraft_mesg/mesg_factory.hpp
+++ b/include/nuraft_mesg/mesg_factory.hpp
@@ -51,8 +51,19 @@ public:
     std::string const raftWorkerName() const;
     std::string const dataWorkerName() const;
 
+    // NuRaft rpc_client_factory entry point. Only NuRaft needs a new wrapper /
+    // rpc_client::get_id() so delayed callbacks can be treated as stale; that is
+    // why create_client(string) always force-recreates. All other internal paths
+    // use create_or_reinit_client(), which reuses the wrapper and only refreshes
+    // the underlying messaging_client when needed.
     nuraft::ptr< nuraft::rpc_client > create_client(const std::string& client) override;
-    nuraft::ptr< nuraft::rpc_client > create_client(peer_id_t const& client);
+
+    // Internal entry points for data-path and out-of-band RPCs.
+    // force_recreate defaults to false: keep the existing wrapper identity and
+    // let reinit_client() refresh messaging_client if required. Pass true only
+    // from the NuRaft create_client(string) path.
+    nuraft::ptr< nuraft::rpc_client > create_or_reinit_client(std::string const& client);
+    nuraft::ptr< nuraft::rpc_client > create_or_reinit_client(peer_id_t const& client, bool force_recreate = false);
 
     virtual nuraft::cmd_result_code create_client(peer_id_t const& client, nuraft::ptr< nuraft::rpc_client >&) = 0;
 
@@ -83,6 +94,7 @@ public:
                   int const max_receive_message_size = 0, int const max_send_message_size = 0);
 
     using grpc_factory::create_client;
+    using grpc_factory::create_or_reinit_client;
     nuraft::cmd_result_code create_client(peer_id_t const& client, nuraft::ptr< nuraft::rpc_client >&) override;
     nuraft::cmd_result_code reinit_client(peer_id_t const& client,
                                           std::shared_ptr< nuraft::rpc_client >& raft_client) override;
@@ -108,6 +120,7 @@ public:
     group_id_t group_id() const { return _group_id; }
 
     using grpc_factory::create_client;
+    using grpc_factory::create_or_reinit_client;
     nuraft::cmd_result_code create_client(peer_id_t const& client, nuraft::ptr< nuraft::rpc_client >& rpc_ptr) override;
 
     nuraft::cmd_result_code reinit_client(peer_id_t const& client,

--- a/src/lib/factory.cpp
+++ b/src/lib/factory.cpp
@@ -110,7 +110,7 @@ void respHandler(std::shared_ptr< ContextType > ctx, std::shared_ptr< nuraft::re
     auto gresp = std::dynamic_pointer_cast< grpc_resp >(rsp);
     LOGD("Updating destination from {} to {}[{}]", ctx->_cur_dest, rsp->get_dst(), gresp->dest_addr);
     ctx->_cur_dest = rsp->get_dst();
-    auto client = factory->create_client(gresp->dest_addr);
+    auto client = factory->create_or_reinit_client(gresp->dest_addr);
 
     // We'll try again by forwarding the message
     auto handler = static_cast< nuraft::rpc_handler >(
@@ -149,33 +149,43 @@ class grpc_error_client : public grpc_base_client {
 
 nuraft::ptr< nuraft::rpc_client > grpc_factory::create_client(std::string const& client) {
     try {
-        return create_client(boost::uuids::string_generator()(client));
+        // Explicit true: NuRaft is the only caller that must observe a new get_id().
+        return create_or_reinit_client(boost::uuids::string_generator()(client), true);
     } catch (std::runtime_error const& e) { LOGC("Client Endpoint Invalid! [{}]", client); }
     return nullptr;
 }
 
-nuraft::ptr< nuraft::rpc_client > grpc_factory::create_client(peer_id_t const& client) {
+nuraft::ptr< nuraft::rpc_client > grpc_factory::create_or_reinit_client(std::string const& client) {
+    try {
+        return create_or_reinit_client(boost::uuids::string_generator()(client));
+    } catch (std::runtime_error const& e) { LOGC("Client Endpoint Invalid! [{}]", client); }
+    return nullptr;
+}
+
+nuraft::ptr< nuraft::rpc_client > grpc_factory::create_or_reinit_client(peer_id_t const& client,
+                                                                        bool const force_recreate) {
     nuraft::ptr< nuraft::rpc_client > new_client;
 
     std::unique_lock< client_factory_lock_type > lk(_client_lock);
     auto [it, happened] = _clients.emplace(client, nullptr);
     if (_clients.end() != it) {
-        if (!happened) {
-            LOGD("Re-creating client for {}", client);
-            if (auto err = reinit_client(client, it->second); nuraft::OK != err) {
-                LOGW("Failed to re-initialize client {}: {}", client, err);
-                new_client = std::make_shared< grpc_error_client >();
+        // New entry (happened) or forced recreate both call create_client to get a fresh wrapper;
+        // existing entries on non-forced paths call reinit_client to preserve the wrapper's identity (get_id())
+        // for NuRaft stale-callback detection.
+        bool const do_create = happened || force_recreate;
+        auto const action = do_create ? "create" : "reinit";
+        LOGD("{} client for {}", action, client);
+        auto const err = do_create ? create_client(client, it->second) : reinit_client(client, it->second);
+        if (nuraft::OK != err) {
+            // First-time creation failure (happened) is louder than a reinit failure.
+            if (happened) {
+                LOGE("Failed to create client {}: {}", client, err);
             } else {
-                new_client = it->second;
+                LOGW("Failed to {} client {}: {}", action, client, err);
             }
+            new_client = std::make_shared< grpc_error_client >();
         } else {
-            LOGD("Creating client for {}", client);
-            if (auto err = create_client(client, it->second); nuraft::OK != err) {
-                LOGE("Failed to create client for {}: {}", client, err);
-                new_client = std::make_shared< grpc_error_client >();
-            } else {
-                new_client = it->second;
-            }
+            new_client = it->second;
         }
         if (!it->second) { _clients.erase(it); }
     }
@@ -184,7 +194,7 @@ nuraft::ptr< nuraft::rpc_client > grpc_factory::create_client(peer_id_t const& c
 
 NullAsyncResult grpc_factory::add_server(uint32_t const srv_id, peer_id_t const& srv_addr,
                                          nuraft::srv_config const& dest_cfg) {
-    auto client = create_client(dest_cfg.get_endpoint());
+    auto client = create_or_reinit_client(dest_cfg.get_endpoint());
     if (!client) { return folly::makeUnexpected(nuraft::CANCELLED); }
 
     auto ctx = std::make_shared< client_ctx< uint32_t > >(srv_id, shared_from_this(), dest_cfg.get_id(), srv_addr);
@@ -199,7 +209,7 @@ NullAsyncResult grpc_factory::add_server(uint32_t const srv_id, peer_id_t const&
 }
 
 NullAsyncResult grpc_factory::rem_server(uint32_t const srv_id, nuraft::srv_config const& dest_cfg) {
-    auto client = create_client(dest_cfg.get_endpoint());
+    auto client = create_or_reinit_client(dest_cfg.get_endpoint());
     if (!client) { return folly::makeUnexpected(nuraft::CANCELLED); }
 
     auto ctx = std::make_shared< client_ctx< int32_t > >(srv_id, shared_from_this(), dest_cfg.get_id());
@@ -214,7 +224,7 @@ NullAsyncResult grpc_factory::rem_server(uint32_t const srv_id, nuraft::srv_conf
 }
 
 NullAsyncResult grpc_factory::append_entry(std::shared_ptr< nuraft::buffer > buf, nuraft::srv_config const& dest_cfg) {
-    auto client = create_client(dest_cfg.get_endpoint());
+    auto client = create_or_reinit_client(dest_cfg.get_endpoint());
     if (!client) { return folly::makeUnexpected(nuraft::CANCELLED); }
 
     auto ctx =

--- a/src/proto/proto_mesg_factory.cpp
+++ b/src/proto/proto_mesg_factory.cpp
@@ -190,7 +190,6 @@ public:
 
     ~grpc_proto_client() override = default;
 
-    std::shared_ptr< messaging_client > realClient() { return _client; }
     void setClient(std::shared_ptr< messaging_client > new_client) { _client = new_client; }
     bool reinitRequired() const { return (!_client || 0 < _client->bad_service.load(std::memory_order_relaxed)); }
 
@@ -225,7 +224,7 @@ nuraft::cmd_result_code mesg_factory::create_client(peer_id_t const& client,
                                                     nuraft::ptr< nuraft::rpc_client >& raft_client) {
     // Re-direct this call to a global factory so we can re-use clients to the same endpoints
     LOGD("Creating client to {}", client);
-    auto m_client = std::dynamic_pointer_cast< messaging_client >(_group_factory->create_client(to_string(client)));
+    auto m_client = std::dynamic_pointer_cast< messaging_client >(_group_factory->create_or_reinit_client(client));
     if (!m_client) return nuraft::CANCELLED;
     raft_client = std::make_shared< grpc_proto_client >(m_client, client, _group_id, _group_type, _metrics);
     return (!raft_client) ? nuraft::BAD_REQUEST : nuraft::OK;
@@ -235,11 +234,12 @@ nuraft::cmd_result_code mesg_factory::reinit_client(peer_id_t const& client,
                                                     std::shared_ptr< nuraft::rpc_client >& raft_client) {
     LOGD("Re-init client to {}", client);
     auto g_client = std::dynamic_pointer_cast< grpc_proto_client >(raft_client);
-    auto new_raft_client = std::static_pointer_cast< nuraft::rpc_client >(g_client->realClient());
-    if (auto err = _group_factory->reinit_client(client, new_raft_client); err) {
-        return err;
-    }
-    g_client->setClient(std::dynamic_pointer_cast< messaging_client >(new_raft_client));
+    if (!g_client) return nuraft::BAD_REQUEST;
+
+    // Refresh the shared messaging_client through group_factory's cache, then update this wrapper in place.
+    auto m_client = std::dynamic_pointer_cast< messaging_client >(_group_factory->create_or_reinit_client(client));
+    if (!m_client) return nuraft::CANCELLED;
+    g_client->setClient(m_client);
     return nuraft::OK;
 }
 
@@ -261,7 +261,7 @@ NullAsyncResult mesg_factory::data_service_request_unidirectional(std::optional<
 
         // Client not found, create a new one
         LOGI("Client not found, attempting to create client for [{}], request name [{}]", dest->value(), request_name);
-        auto client = create_client(dest->value());
+        auto client = create_or_reinit_client(dest->value());
         auto g_client = std::dynamic_pointer_cast< nuraft_mesg::grpc_proto_client >(client);
         if (!g_client) {
             LOGE("Failed to create client for [{}], request name [{}]", dest->value(), request_name);
@@ -305,9 +305,9 @@ mesg_factory::data_service_request_bidirectional(std::optional< Result< peer_id_
         }
     }
 
-    // Client not found or needs reinit - use create_client to handle both cases
+    // Client not found or needs reinit - use create_or_reinit_client to handle both cases
     LOGI("Client not found, attempting to create client for [{}], request name [{}]", dest->value(), request_name);
-    auto client = create_client(dest->value());
+    auto client = create_or_reinit_client(dest->value());
     auto g_client = std::dynamic_pointer_cast< nuraft_mesg::grpc_proto_client >(client);
     if (!g_client) {
         LOGE("Failed to create/reinit client for [{}], request name [{}]", dest->value(), request_name);

--- a/src/tests/raft_service_tests.cpp
+++ b/src/tests/raft_service_tests.cpp
@@ -135,3 +135,116 @@ TEST_F(MessagingFixture, BasicTests) {
     // Needed since app_4 is not part of TearDown
     app_4->instance_->leave_group(group_id_);
 }
+
+// NuRaft peer::recreate_rpc() calls factory->create_client() again and relies on
+// rpc_client::get_id() changing so delayed responses are treated as stale and
+// skip bytes_in_flight_sub(). mesg_factory must mint a new outer wrapper on
+// reinit even when the underlying messaging_client is reused.
+TEST_F(MessagingFixture, RecreateClientChangesRpcId) {
+    auto factory = std::make_shared< mesg_factory >(custom_factory_, group_id_, "test_type");
+
+    auto first = factory->create_client(to_string(app_2_->id_));
+    ASSERT_NE(first, nullptr);
+    auto const first_id = first->get_id();
+
+    auto second = factory->create_client(to_string(app_2_->id_));
+    ASSERT_NE(second, nullptr);
+
+    EXPECT_NE(first.get(), second.get()) << "recreate must return a new rpc_client object";
+    EXPECT_NE(first_id, second->get_id()) << "recreate must change rpc_client::get_id() for NuRaft stale check";
+}
+
+TEST_F(MessagingFixture, DataPathReinitPreservesRpcClientId) {
+    auto factory = std::make_shared< mesg_factory >(custom_factory_, group_id_, "test_type");
+    auto const peer = app_2_->id_;
+
+    auto first = factory->create_client(to_string(peer));
+    ASSERT_NE(first, nullptr);
+    auto const first_transport = custom_factory_->cached_transport(peer);
+    ASSERT_NE(first_transport, nullptr);
+
+    custom_factory_->force_recreate(true);
+    auto refreshed = factory->create_or_reinit_client(peer);
+    custom_factory_->force_recreate(false);
+
+    ASSERT_NE(refreshed, nullptr);
+    EXPECT_EQ(refreshed.get(), first.get()) << "data-path reinit must preserve the existing wrapper";
+    EXPECT_EQ(refreshed->get_id(), first->get_id()) << "data-path reinit must preserve rpc_client identity";
+    EXPECT_NE(custom_factory_->cached_transport(peer), first_transport)
+        << "data-path reinit must still refresh the shared messaging_client";
+}
+
+// Two raft groups share one group_factory. Verify the shared messaging_client
+// cache: initial creates share one transport; after group1 replaces it, group2
+// must adopt that same refreshed transport on its next create/reinit.
+TEST_F(MessagingFixture, SharedGroupFactoryReusesReinitTransport) {
+    auto group1 = std::make_shared< mesg_factory >(custom_factory_, group_id_, "test_type");
+    auto const group2_id = boost::uuids::random_generator()();
+    auto group2 = std::make_shared< mesg_factory >(custom_factory_, group2_id, "test_type");
+    auto const peer = app_2_->id_;
+
+    ASSERT_NE(group1->create_client(to_string(peer)), nullptr);
+    auto const group1_initial_transport = custom_factory_->cached_transport(peer);
+    ASSERT_NE(group1_initial_transport, nullptr);
+
+    ASSERT_NE(group2->create_or_reinit_client(peer), nullptr);
+    auto const group2_initial_transport = custom_factory_->cached_transport(peer);
+    EXPECT_EQ(group2_initial_transport, group1_initial_transport)
+        << "both groups must initially share one messaging_client";
+
+    // Replace the shared transport once (simulates dead connection / bad_service).
+    custom_factory_->force_recreate(true);
+    ASSERT_NE(group1->create_client(to_string(peer)), nullptr);
+    custom_factory_->force_recreate(false);
+
+    auto const group1_refreshed_transport = custom_factory_->cached_transport(peer);
+    ASSERT_NE(group1_refreshed_transport, nullptr);
+    EXPECT_NE(group1_refreshed_transport, group1_initial_transport)
+        << "group1 reinit must publish a new messaging_client into the shared cache";
+    EXPECT_EQ(group2_initial_transport, group1_initial_transport)
+        << "group2 still observes the original transport until it reinits";
+
+    ASSERT_NE(group2->create_or_reinit_client(peer), nullptr);
+    EXPECT_EQ(custom_factory_->cached_transport(peer), group1_refreshed_transport)
+        << "group2 reinit must reuse group1's refreshed messaging_client, not allocate another";
+}
+
+// Counterpart to SharedGroupFactoryReusesReinitTransport where the DATA PATH
+// (not NuRaft recreate_rpc) is the trigger that replaces the shared transport.
+// After group1's data-path reinit updates group_factory's cache, group2's next
+// reinit must adopt that transport instead of allocating a separate connection.
+TEST_F(MessagingFixture, SharedGroupFactoryDataPathUpdatesCache) {
+    auto group1 = std::make_shared< mesg_factory >(custom_factory_, group_id_, "test_type");
+    auto const group2_id = boost::uuids::random_generator()();
+    auto group2 = std::make_shared< mesg_factory >(custom_factory_, group2_id, "test_type");
+    auto const peer = app_2_->id_;
+
+    // raft_held simulates NuRaft's peer._rpc after recreate_rpc().
+    auto raft_held = group1->create_client(to_string(peer));
+    ASSERT_NE(raft_held, nullptr);
+    ASSERT_NE(group2->create_or_reinit_client(peer), nullptr);
+    auto const initial_transport = custom_factory_->cached_transport(peer);
+    ASSERT_NE(initial_transport, nullptr);
+
+    // group1 data-path reinit replaces the shared transport in group_factory.
+    custom_factory_->force_recreate(true);
+    auto data_path_result = group1->create_or_reinit_client(peer);
+    custom_factory_->force_recreate(false);
+
+    ASSERT_NE(data_path_result, nullptr);
+    // data-path reinit calls setClient() on the existing wrapper in place, so the
+    // object NuRaft holds (raft_held) is the same object that now points to the
+    // new transport - no extra send failure needed before NuRaft benefits.
+    EXPECT_EQ(data_path_result.get(), raft_held.get())
+        << "data-path reinit must update NuRaft's held wrapper in place, not replace it";
+
+    auto const refreshed_transport = custom_factory_->cached_transport(peer);
+    ASSERT_NE(refreshed_transport, nullptr);
+    EXPECT_NE(refreshed_transport, initial_transport)
+        << "data-path reinit must publish a new messaging_client into group_factory cache";
+
+    // group2's next reinit must reuse refreshed_transport, not create a third connection.
+    ASSERT_NE(group2->create_or_reinit_client(peer), nullptr);
+    EXPECT_EQ(custom_factory_->cached_transport(peer), refreshed_transport)
+        << "group2 reinit must adopt the transport already in group_factory, not allocate another";
+}

--- a/src/tests/test_fixture.ipp
+++ b/src/tests/test_fixture.ipp
@@ -113,6 +113,23 @@ struct custom_factory : public nuraft_mesg::group_factory {
     custom_factory(int const raft_threads, int const data_threads, nuraft_mesg::group_id_t const& name) :
             nuraft_mesg::group_factory::group_factory(raft_threads, data_threads, name, nullptr) {}
 
+    // This fixture treats the cached messaging_client as healthy unless the
+    // test explicitly forces a reconnect. This avoids coupling cache-sharing
+    // tests to the asynchronous gRPC channel readiness state.
+    nuraft::cmd_result_code reinit_client(nuraft_mesg::peer_id_t const& client,
+                                          std::shared_ptr< nuraft::rpc_client >& raft_client) override {
+        if (force_recreate_) { return group_factory::create_client(client, raft_client); }
+        return nuraft::OK;
+    }
+
+    void force_recreate(bool value) { force_recreate_ = value; }
+
+    std::shared_ptr< nuraft::rpc_client > cached_transport(nuraft_mesg::peer_id_t const& peer) {
+        std::shared_lock< client_factory_lock_type > lock(_client_lock);
+        auto const it = _clients.find(peer);
+        return it == _clients.end() ? nullptr : it->second;
+    }
+
     std::string lookupEndpoint(nuraft_mesg::peer_id_t const& peer) override {
         auto lg = std::scoped_lock(lookup_lock_);
         return (lookup_map_.count(peer) > 0) ? lookup_map_[peer] : std::string();
@@ -124,6 +141,7 @@ struct custom_factory : public nuraft_mesg::group_factory {
     }
     std::mutex lookup_lock_;
     std::map< nuraft_mesg::peer_id_t, std::string > lookup_map_;
+    bool force_recreate_{false};
 };
 
 extern nuraft::ptr< nuraft::cluster_config > fromClusterConfig(nlohmann::json const& cluster_config);


### PR DESCRIPTION
NuRaft identifies stale callbacks by rpc_client::get_id(). Reinit used to keep the same grpc_proto_client and only swap the inner connection, keeping the client id unchanged a cross different RPCs may lead to unexpected behavior (e.g., delayed append-entries responses could underflow bytes_in_flight. Always replace the outer wrapper while still allowing group_factory to reuse a healthy messaging_client.